### PR TITLE
fix tools/runtest.py to make the tests pass again

### DIFF
--- a/tools/runtest.py
+++ b/tools/runtest.py
@@ -12,7 +12,7 @@ def runHB(row, font, positions=False):
             "--script=%s"    %row[1],
             "--language=%s"  %row[2],
             "--features=%s"  %row[3],
-            "--text=%s"      %row[4]]
+            isinstance(row[4], unicode) and row[4].encode('utf-8') or row[4]]
     process = subprocess.Popen(args, stdout=subprocess.PIPE)
     return process.communicate()[0].strip()
 


### PR DESCRIPTION
Hi,

I had two different problems when running `make check` with hb-shape from the current (as in today https://github.com/behdad/harfbuzz/commit/7481bd49) harfbuzz master.

This commit made all tests pass again. However, I'm not sure if it's the best solution.

The first, initial problem was harfbuzz complaining:

> hb-shape: Invalid byte sequence in conversion input
Try `hb-shape --help' for more information.

I got rid of that by using the positional `[TEXT]` argument of harfbuzz, rather than the `--text=` option. 

Then some tests passed until `test-suite/basic.test`, where  I got an error from `subprocess.py`:

> subprocess.py", line 1335, in _execute_child
    raise child_exception
TypeError: execv() arg 2 must contain only strings

That was when I added that `isinstance(row[4], unicode) and row[4].encode('utf-8') or row[4]` conditional behavior.